### PR TITLE
Feat: support batch adding songs from YouTube playlist

### DIFF
--- a/src/apis/backendApis.js
+++ b/src/apis/backendApis.js
@@ -97,3 +97,9 @@ export async function fetchVideoTitle(yid) {
   const title = data?.title;
   return title;
 }
+
+export async function fetchPlaylistVideos(playlistUrl) {
+  const apiEntry = "/api/playlist/fetch";
+  const data = await actionPOST(apiEntry, { url: playlistUrl });
+  return data?.videos || [];
+}

--- a/src/apis/backendApis.js
+++ b/src/apis/backendApis.js
@@ -99,7 +99,7 @@ export async function fetchVideoTitle(yid) {
 }
 
 export async function fetchPlaylistById(playlistId) {
-  const apiEntry = "/api/playlist/fetch";
-  const data = await actionPOST(apiEntry, { playlistId });
+  const apiEntry = `/api/video/getplaylist?playlistid=${playlistId}`;
+  const data = await actionGET(apiEntry);
   return data?.videos || [];
 }

--- a/src/apis/backendApis.js
+++ b/src/apis/backendApis.js
@@ -98,8 +98,8 @@ export async function fetchVideoTitle(yid) {
   return title;
 }
 
-export async function fetchPlaylistVideos(playlistUrl) {
+export async function fetchPlaylistById(playlistId) {
   const apiEntry = "/api/playlist/fetch";
-  const data = await actionPOST(apiEntry, { url: playlistUrl });
+  const data = await actionPOST(apiEntry, { playlistId });
   return data?.videos || [];
 }

--- a/src/components/YoutubePanel.jsx
+++ b/src/components/YoutubePanel.jsx
@@ -6,7 +6,7 @@ import {
   fetchRoomInfo,
   fetchUserInfo,
   fetchVideoTitle,
-  fetchPlaylistVideos
+  fetchPlaylistById
 } from "../apis/backendApis";
 import { io } from "socket.io-client";
 import { UserContext } from "../contexts/UserContext";
@@ -56,7 +56,7 @@ function YoutubePanel({
     const secs = Math.floor(seconds % 60);
     return `${minutes}:${secs.toString().padStart(2, "0")}`;
   };
-
+  
   useEffect(() => {
     const interval = setInterval(() => {
       if (playerRef.current && isPlaying() && !isDragging) {
@@ -434,41 +434,40 @@ function YoutubePanel({
   </InputGroup>
 
   <InputGroup>
-    {/* Playlist input */}
-    <StyledInput
-      type="text"
-      placeholder="Enter YouTube Playlist URL"
-      value={playlistUrl}
-      onChange={(e) => setPlaylistUrl(e.target.value)}
-    />
-    <StyledControlButton
-      onClick={async () => {
-        const videos = await fetchPlaylistVideos(playlistUrl);
-        if (!videos.length) {
-          alert("Failed to load the playlist.");
-          return;
-        }
+  <StyledInput
+    type="text"
+    placeholder="Enter YouTube Playlist ID"
+    value={playlistUrl}
+    onChange={(e) => setPlaylistUrl(e.target.value)}
+  />
+  <StyledControlButton
+    onClick={async () => {
+      const videos = await fetchPlaylistById(playlistUrl); 
+      if (!videos.length) {
+        alert("Failed to load the playlist.");
+        return;
+      }
 
-        socketRef.current.emit("send_message", {
-          room_id: id,
-          message_type: "add_playlist",
-          videos: videos.map((v) => ({
-            title: v.title,
-            youtube_id: v.youtube_id,
-            added_by: uid,
-          })),
-        });
+      socketRef.current.emit("send_message", {
+        room_id: id,
+        message_type: "add_playlist",
+        videos: videos.map((v) => ({
+          title: v.title,
+          youtube_id: v.youtube_id,
+          added_by: uid,
+        })),
+      });
 
-        setQueueList((prev) => [
-          ...prev,
-          ...videos.map((v) => ({ title: v.title, youtubeId: v.youtube_id })),
-        ]);
-        alert("Playlist has been added to the queue!");
-      }}
-    >
-      Add Playlist
-    </StyledControlButton>
-  </InputGroup>
+      setQueueList((prev) => [
+        ...prev,
+        ...videos.map((v) => ({ title: v.title, youtubeId: v.youtube_id })),
+      ]);
+      alert("Playlist has been added to the queue!");
+    }}
+  >
+    Add Playlist by ID
+  </StyledControlButton>
+</InputGroup>
 
     {/* preset loding */}
   <InputGroup>

--- a/src/components/YoutubePanel.jsx
+++ b/src/components/YoutubePanel.jsx
@@ -410,7 +410,7 @@ function YoutubePanel({
 
 
 <div>
-  {/* YouTube ID 입력 */}
+  {/* YouTube ID input */}
   <InputGroup>
     <StyledInput
       type="text"
@@ -434,7 +434,7 @@ function YoutubePanel({
   </InputGroup>
 
   <InputGroup>
-    {/* Playlist 입력 */}
+    {/* Playlist input */}
     <StyledInput
       type="text"
       placeholder="Enter YouTube Playlist URL"
@@ -445,7 +445,7 @@ function YoutubePanel({
       onClick={async () => {
         const videos = await fetchPlaylistVideos(playlistUrl);
         if (!videos.length) {
-          alert("플레이리스트를 불러오지 못했어요.");
+          alert("Failed to load the playlist.");
           return;
         }
 
@@ -463,14 +463,14 @@ function YoutubePanel({
           ...prev,
           ...videos.map((v) => ({ title: v.title, youtubeId: v.youtube_id })),
         ]);
-        alert("재생목록이 큐에 추가되었어요!");
+        alert("Playlist has been added to the queue!");
       }}
     >
       Add Playlist
     </StyledControlButton>
   </InputGroup>
 
-    {/* 프리셋 로딩 */}
+    {/* preset loding */}
   <InputGroup>
     <StyledControlButton
       onClick={async () => {

--- a/src/components/YoutubePanel.jsx
+++ b/src/components/YoutubePanel.jsx
@@ -464,7 +464,6 @@ function YoutubePanel({
                   youtubeId: v.youtube_id,
                 })),
               ]);
-              alert("Playlist has been added to the queue!");
             }}
           >
             Add Playlist by ID

--- a/src/pages/RoomPage.jsx
+++ b/src/pages/RoomPage.jsx
@@ -65,11 +65,8 @@ function RoomPage() {
         <QueuePanel>
           <QueueHeader>Queue</QueueHeader>
           {queueList.map((song, i) => (
-            <QueueItem key={song.youtubeId}>
-              <span role="img" aria-label="music">
-                🎵
-              </span>{" "}
-              {song.title}
+            <QueueItem key={`${song.youtubeId}-${i}`}>
+              <span role="img" aria-label="music">🎵</span> {song.title}
             </QueueItem>
           ))}
         </QueuePanel>


### PR DESCRIPTION
# New Pull Request

## Description

- **What kind of change does this PR introduce?** 
Feature: Add support for importing YouTube playlists (frontend)

- **What is the current behavior?**
Users can only add individual YouTube videos by entering their video ID one at a time.

- **What is the new behavior?**
1. Users can now paste a YouTube playlist URL.
2. The frontend sends the URL to the backend API (/api/playlist/fetch) and receives a list of videos.
3. All videos are added to the current room’s queue via the "add_playlist" socket message.

- **Other information**:
A new input field and Add Playlist button were added to YoutubePanel.jsx

![image](https://github.com/user-attachments/assets/d16cf3db-9a26-47db-8e77-2726c45f6dec)


## Check-List

1. [x] I have tested and performed a self-review of my code
2. [x] I have followed the guidelines in the Contributing document
3. [x] I have checked there aren't other open [Pull Requests](../../../pulls) for the same update/change

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #14 
